### PR TITLE
Update super-admin-all-sites-menu.php

### DIFF
--- a/super-admin-all-sites-menu.php
+++ b/super-admin-all-sites-menu.php
@@ -438,7 +438,7 @@ class SuperAdminAllSitesMenu {
 			]
 		);
 
-		wp_add_inline_script( 'super-admin-all-sites-menu', "const pluginAllSitesMenu = ${data};", 'before' );
+		wp_add_inline_script( 'super-admin-all-sites-menu', "const pluginAllSitesMenu = {$data};", 'before' );
 		wp_set_script_translations( 'super-admin-all-sites-menu', 'super-admin-all-sites-menu' );
 	}
 


### PR DESCRIPTION
Fixes deprecation warning "Using ${var} in strings is deprecated, use {$var} instead" for PHP 8.2+

Fixes #23