### PR TITLE
Remove duplicate code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
 # Changelog
 
-### 1.8.0 
+### 1.8.1
+
+- Remove duplicate code.
+
+### 1.8.0
 
 > REQUIRE PHP 8.0 OR HIGHER
 
 #### Added
+
 - New Config class to manage plugin constants
 - Constructor property promotion for better code organization
 - Strict type declarations throughout the codebase
 
 #### Changed
+
 - Increased default search threshold from 2 to 20 sites
 - Refactored main class to use modern PHP 8.0+ features
 - Improved error handling and null checks
@@ -17,6 +23,7 @@
 - Simplified plugin initialization
 
 #### Developer Notes
+
 - The Config class now centralizes all plugin constants
 - Removed redundant property declarations in favor of constructor property promotion
 - Added strict typing for better code reliability
@@ -281,5 +288,3 @@
 ### 1.0.x
 
 - Initial release.
-
-

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => '8a8e912db6e7c0137fcb');
+<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => '1ebd4f27cd4018d342f4');

--- a/build/index.js
+++ b/build/index.js
@@ -1,6 +1,6 @@
 /*!
  * super-admin-all-sites-menu
- * version: 1.8.0
+ * version: 1.8.1
  * address: https://github.com/soderlind/super-admin-all-sites-menu#readme
  * author:  Per Søderlind
  * license: GPLv2

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "soderlind/super-admin-all-sites-menu",
   "description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "keywords": [
     "wordpress",
     "multisite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Super Admin All Sites Menu ===
-Stable tag: 1.8.0
+Stable tag: 1.8.1
 Requires at least: 5.6  
 Tested up to: 6.7  
 Requires PHP: 8.0  
@@ -107,6 +107,10 @@ You can use the following filters to override the defaults:
 2. Menu data are stored locally in IndexedDB.
 
 == Changelog ==
+
+= 1.8.1 =
+
+* Remove duplicate code
 
 = 1.8.0 =
 

--- a/super-admin-all-sites-menu.php
+++ b/super-admin-all-sites-menu.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * Description: For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.
- * Version:     1.8.0
+ * Version:     1.8.1
  * Author:      Per Soderlind
  * Network:     true
  * Author URI:  https://soderlind.no
@@ -93,14 +93,6 @@ final class SuperAdminAllSitesMenu {
 			add_action( 'admin_enqueue_scripts', [ $this, 'action_enqueue_scripts' ] );
 			add_action( 'wp_enqueue_scripts', [ $this, 'action_enqueue_scripts' ] );
 		}
-		add_action( 'wp_insert_site', [ $this, 'update_local_storage' ] );
-		add_action( 'wp_update_site', [ $this, 'update_local_storage' ] );
-		add_action( 'wp_delete_site', [ $this, 'update_local_storage' ] );
-
-		add_action( 'update_option_blogname', [ $this, 'action_update_option_blogname' ], 10, 3 );
-
-		add_action( 'activated_plugin', [ $this, 'plugin_update_local_storage' ], 10, 1 );
-		add_action( 'deactivated_plugin', [ $this, 'plugin_update_local_storage' ], 10, 1 );
 
 		$this->number_of_sites = $this->get_number_of_sites();
 	}


### PR DESCRIPTION
This pull request focuses on updating the version of the `super-admin-all-sites-menu` plugin to 1.8.1, removing duplicate code, and making necessary adjustments to the documentation and metadata files. The most important changes include updating version numbers, removing duplicate code, and updating the changelog.

Version updates:

* [`build/index.js`](diffhunk://#diff-b45a82899e064eecd30590584dc256fbf4aecbf4a782d303c94091b56d659a50L3-R3): Updated version from 1.8.0 to 1.8.1.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L4-R4): Updated version from 1.8.0 to 1.8.1.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated version from 1.8.0 to 1.8.1.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L2-R2): Updated stable tag from 1.8.0 to 1.8.1.
* [`super-admin-all-sites-menu.php`](diffhunk://#diff-f376cc60146d9f72a1b7bf6d03d2268dc3087c33dd26bc4a98cd1f87bdfe48afL15-R15): Updated version from 1.8.0 to 1.8.1.

Code removal:

* [`super-admin-all-sites-menu.php`](diffhunk://#diff-f376cc60146d9f72a1b7bf6d03d2268dc3087c33dd26bc4a98cd1f87bdfe48afL96-L103): Removed duplicate code related to site and plugin update actions.

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R26): Added version 1.8.1 entry and removed duplicate code note.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R111-R114): Added version 1.8.1 entry in the changelog section.