### PR TITLE
Enhance GitHub Actions workflow for WordPress deployment with attesta…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,18 +2,29 @@ name: Deploy to WordPress.org
 on:
   push:
     tags:
-    - "*"
+      - '*'
 jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     steps:
-    - name: Install Subversion
-      run: sudo apt-get update && sudo apt-get install -y subversion
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        id: deploy
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        with:
+          generate-zip: true
+      - name: Generate build provenance attestation
+        uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
+        with:
+          zip-path: ${{ steps.deploy.outputs.zip-path }}

--- a/super-admin-all-sites-menu.php
+++ b/super-admin-all-sites-menu.php
@@ -54,6 +54,11 @@ final class SuperAdminAllSitesMenu {
 		private int $cache_expiration = Config::CACHE_EXPIRATION
 	) {}
 
+	/**
+	 * Initialize the plugin.
+	 *
+	 * @return void
+	 */
 	public function init(): void {
 
 		// Only for super admins and REST API requests.
@@ -75,6 +80,11 @@ final class SuperAdminAllSitesMenu {
 		$this->register_hooks();
 	}
 
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
 	private function register_hooks(): void {
 		add_action( 'admin_bar_init', [ $this, 'action_admin_bar_init' ] );
 		add_action( 'rest_api_init', [ $this, 'action_rest_api_init' ] );
@@ -446,7 +456,7 @@ final class SuperAdminAllSitesMenu {
 	}
 
 	/**
-	 * Fires after the a blog is renamed.
+	 * Fires after a blog is renamed.
 	 *
 	 * @param mixed  $old_value The old option value.
 	 * @param mixed  $value     The new option value.


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for deploying to WordPress.org. The most important changes involve refining the tag push triggers, adding permissions for jobs, and incorporating steps for generating build provenance attestation.

Workflow improvements:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L5-R30): Adjusted the tag push triggers to use single quotes for consistency.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L5-R30): Added write permissions for `attestations` and `id-token`, and read permissions for `contents` to the `tag` job.

Deployment enhancements:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L5-R30): Added an `id` for the `WordPress Plugin Deploy` step and configured it to generate a zip file.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L5-R30): Introduced a new step to generate build provenance attestation using the `johnbillion/action-wordpress-plugin-attestation@0.7.0` action.