### PR TITLE
Fix demo URL in README.md and readme.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can use the following filters to override the defaults:
 
 ## Demo
 
-A demo is available in [WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/soderlind/super-admin-all-sites-menu/refs/heads/main/.wordpress-org/blueprints/blueprint.json). It's a bit slow loading, 50 subsites are added.
+A demo is available in [WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/soderlind/super-admin-all-sites-menu/refs/heads/main/blueprint.json). It's a bit slow loading, 50 subsites are added.
 
 - If you disable Super Admin All Sites Menu in the Main Site plugins menu, you'll see the WP Admin Bar My Sites menu doesn't allow you to scroll and see all sites. This is a 14-year-old (!) [bug on WordPress](https://core.trac.wordpress.org/ticket/15317).
 

--- a/blueprint.json
+++ b/blueprint.json
@@ -12,6 +12,16 @@
 	},
 	"steps": [
 		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "restricted-site-access"
+			},
+			"options": {
+				"activate": false
+			}
+		},
+		{
 			"step": "enableMultisite"
 		},
 		{

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.
 
 = Demo =
 
-A demo is available in [WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/soderlind/super-admin-all-sites-menu/refs/heads/main/.wordpress-org/blueprints/blueprint.json). It's a bit slow loading, 50 subsites are added.
+A demo is available in [WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/soderlind/super-admin-all-sites-menu/refs/heads/main/blueprint.json). It's a bit slow loading, 50 subsites are added.
 
 - If you disable Super Admin All Sites Menu in the Main Site plugins menu, you'll see the WP Admin Bar My Sites menu doesn't allow you to scroll and see all sites. This is a 14-year-old (!) [bug on WordPress](https://core.trac.wordpress.org/ticket/15317).
 


### PR DESCRIPTION
This pull request includes several changes to the blueprint configuration and documentation for the WordPress project. The most important changes involve adding a new blueprint configuration file, modifying existing blueprint steps, and updating demo links in the documentation.

Changes to blueprint configuration:

* Added a new `blueprint.json` file with schema, site options, and multiple steps to create 50 subsites and install a plugin.
* Removed the `installPlugin` step for the `restricted-site-access` plugin from `.wordpress-org/blueprints/blueprint.json`.

Updates to documentation:

* Updated demo link in `README.md` to point to the new `blueprint.json` file.
* Updated demo link in `readme.txt` to point to the new `blueprint.json` file.