### PR TITLE
Remove self installation

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -4,13 +4,20 @@
 	"features": {
 		"networking": true
 	},
-	"plugins": [
-		"https://github-proxy.com/proxy/?repo=soderlind/super-admin-all-sites-menu"
-	],
 	"siteOptions": {
 		"blogname": "Main Site"
 	},
 	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "restricted-site-access"
+			},
+			"options": {
+				"activate": false
+			}
+		},
 		{
 			"step": "enableMultisite"
 		},


### PR DESCRIPTION
This pull request includes changes to the `.wordpress-org/blueprints/blueprint.json` file to update the plugin installation steps and remove an outdated plugin reference. The most important changes are as follows:

Plugin management:

* Removed plugin reference to `super-admin-all-sites-menu`.
* Added a new step to install the `restricted-site-access` plugin from `wordpress.org/plugins`, with the option to not activate it immediately.