### PR TITLE
Bump version to 1.8.5 in all relevant files; update dependencies in p…

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => '0526fd5ab9d497a196d1');
+<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => 'da544fcd5cb42ed37570');

--- a/build/index.js
+++ b/build/index.js
@@ -1,6 +1,6 @@
 /*!
  * super-admin-all-sites-menu
- * version: 1.8.4
+ * version: 1.8.5
  * address: https://github.com/soderlind/super-admin-all-sites-menu#readme
  * author:  Per Søderlind
  * license: GPLv2

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
-  "name": "soderlind/super-admin-all-sites-menu",
-  "description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
-  "version": "1.8.4",
-  "keywords": [
-    "wordpress",
-    "multisite",
-    "superadmin",
-    "admin"
-  ],
-  "type": "wordpress-plugin",
-  "homepage": "https://github.com/soderlind/super-admin-all-sites-menu",
-  "license": "GPL-2.0-or-later",
-  "require": {}
+	"name": "soderlind/super-admin-all-sites-menu",
+	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
+	"version": "1.8.5",
+	"keywords": [
+		"wordpress",
+		"multisite",
+		"superadmin",
+		"admin"
+	],
+	"type": "wordpress-plugin",
+	"homepage": "https://github.com/soderlind/super-admin-all-sites-menu",
+	"license": "GPL-2.0-or-later",
+	"require": {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.8.3",
+	"version": "1.8.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "super-admin-all-sites-menu",
-			"version": "1.8.3",
+			"version": "1.8.4",
 			"license": "GPLv2",
 			"dependencies": {
 				"@soderlind/wp-project-version-sync": "^2.0.2",
-				"@wordpress/api-fetch": "^7.16.0",
-				"@wordpress/i18n": "^5.16.0",
+				"@wordpress/api-fetch": "^7.9.0",
+				"@wordpress/i18n": "^5.9.0",
 				"cross-spawn": "^7.0.6",
 				"dexie": "^4.0.11"
 			},
 			"devDependencies": {
-				"@wordpress/scripts": "^30.9.0",
-				"terser-webpack-plugin": "^5.3.11"
+				"@wordpress/scripts": "^30.7.0",
+				"terser-webpack-plugin": "^5.3.14"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -382,25 +382,25 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-			"integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+			"integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.0"
+				"@babel/template": "^7.26.9",
+				"@babel/types": "^7.26.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-			"integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+			"integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.0"
+				"@babel/types": "^7.26.10"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1847,14 +1847,14 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-			"integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+			"version": "7.26.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+			"integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.25.9",
-				"@babel/parser": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.26.9",
+				"@babel/types": "^7.26.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1879,9 +1879,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-			"integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+			"integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.25.9",
@@ -2226,14 +2226,14 @@
 			}
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.2.tgz",
-			"integrity": "sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.3.tgz",
+			"integrity": "sha512-pJT1OkhplSmvvr6i3CWTPvC/FGC06MbN5TNBfRO6Ox62AEz90eMq+dVvtX9Bl3jxCEkS0tATzDarRZuOLw7oFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@formatjs/fast-memoize": "2.2.6",
-				"@formatjs/intl-localematcher": "0.5.10",
+				"@formatjs/intl-localematcher": "0.6.0",
 				"decimal.js": "10",
 				"tslib": "2"
 			}
@@ -2249,32 +2249,32 @@
 			}
 		},
 		"node_modules/@formatjs/icu-messageformat-parser": {
-			"version": "2.9.8",
-			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.8.tgz",
-			"integrity": "sha512-hZlLNI3+Lev8IAXuwehLoN7QTKqbx3XXwFW1jh0AdIA9XJdzn9Uzr+2LLBspPm/PX0+NLIfykj/8IKxQqHUcUQ==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.1.tgz",
+			"integrity": "sha512-o0AhSNaOfKoic0Sn1GkFCK4MxdRsw7mPJ5/rBpIqdvcC7MIuyUSW8WChUEvrK78HhNpYOgqCQbINxCTumJLzZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@formatjs/ecma402-abstract": "2.3.2",
-				"@formatjs/icu-skeleton-parser": "1.8.12",
+				"@formatjs/ecma402-abstract": "2.3.3",
+				"@formatjs/icu-skeleton-parser": "1.8.13",
 				"tslib": "2"
 			}
 		},
 		"node_modules/@formatjs/icu-skeleton-parser": {
-			"version": "1.8.12",
-			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.12.tgz",
-			"integrity": "sha512-QRAY2jC1BomFQHYDMcZtClqHR55EEnB96V7Xbk/UiBodsuFc5kujybzt87+qj1KqmJozFhk6n4KiT1HKwAkcfg==",
+			"version": "1.8.13",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.13.tgz",
+			"integrity": "sha512-N/LIdTvVc1TpJmMt2jVg0Fr1F7Q1qJPdZSCs19unMskCmVQ/sa0H9L8PWt13vq+gLdLg1+pPsvBLydL1Apahjg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@formatjs/ecma402-abstract": "2.3.2",
+				"@formatjs/ecma402-abstract": "2.3.3",
 				"tslib": "2"
 			}
 		},
 		"node_modules/@formatjs/intl-localematcher": {
-			"version": "0.5.10",
-			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
-			"integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.0.tgz",
+			"integrity": "sha512-4rB4g+3hESy1bHSBG3tDFaMY2CH67iT7yne1e+0CLTsGLDcmoEWWpJjjpWVaYgYfYuohIRuo0E+N536gd2ZHZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2747,9 +2747,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -2921,9 +2921,9 @@
 			}
 		},
 		"node_modules/@keyv/serialize": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.2.tgz",
-			"integrity": "sha512-+E/LyaAeuABniD/RvUezWVXKpeuvwLEA9//nE9952zBaOdBd2mQ3pPoM8cUe2X6IcMByfuSLzmYqnYshG60+HQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
+			"integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3321,9 +3321,9 @@
 			}
 		},
 		"node_modules/@paulirish/trace_engine": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.39.tgz",
-			"integrity": "sha512-2Y/ejHX5DDi5bjfWY/0c/BLVSfQ61Jw1Hy60Hnh0hfEO632D3FVctkzT4Q/lVAdvIPR0bUaok9JDTr1pu/OziA==",
+			"version": "0.0.44",
+			"resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.44.tgz",
+			"integrity": "sha512-QjDv5qVaUXd5WZzE2ktKvqtGA17v4HFtj6MROCGkK57AZr9n0ZKgcx7dEFho+5EHZ6V6h1upW2eqheo8C4Y4dA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3344,14 +3344,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
+			"integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.49.1"
+				"playwright": "1.51.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3440,9 +3440,9 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3610,9 +3610,9 @@
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.1.tgz",
-			"integrity": "sha512-XagAHHIa528EvyGybv8EEYGK5zrVW74cHpsjhtovVATbhDRuJYfE+X4HCaAieW9lCkwbX6L+X0I4CiUG3w/hFw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.2.tgz",
+			"integrity": "sha512-tylFJGMQo62alGazK74MNxFjMagYOHmBZiePZFOJK2n13JZta0uVkB3Bh5qodUmOLtRH+uxH297EibK14UKm8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4482,9 +4482,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4613,9 +4613,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4652,9 +4652,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4911,14 +4911,14 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.16.0.tgz",
-			"integrity": "sha512-JMHUUWQQnuFDYQfWtOBPxbB8YEefew3fnGwwDrdOAN7drkZ7ob7fJ2H1tY6iV5i+wIEl/5em3f0jXD3zcwkBDw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.9.0.tgz",
+			"integrity": "sha512-iqH4lNiH8FnIkJ8Nxx4KQYQMd4c/4OwZfjrk0ITwMK5PaVJHnFZ7xZV6ncMbgXbf0VjuPjfKMRmPzxICXw08IQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.16.0",
-				"@wordpress/url": "^4.16.0"
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^5.9.0",
+				"@wordpress/url": "^4.9.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -4926,9 +4926,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.16.0.tgz",
-			"integrity": "sha512-CPAMxQ5eMmsRNJN0edUZvsJDnmALQFGbWyCxsJiJJ/0LFi1lYFC7r5YGcJXVVD+oX9L908NZpxwsQBHb6gkxig==",
+			"version": "8.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.19.1.tgz",
+			"integrity": "sha512-uxXTQS+SGumdQegcaAtPjkUkYUGDmv6xxLf4pJObIHE1+LaYU4PkEciL8gyGxfCpkQinA2FPSJMOoxMAj8/IAQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -4938,8 +4938,8 @@
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
 				"@babel/runtime": "7.25.7",
-				"@wordpress/browserslist-config": "^6.16.0",
-				"@wordpress/warning": "^3.16.0",
+				"@wordpress/browserslist-config": "^6.19.1",
+				"@wordpress/warning": "^3.19.1",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -5119,9 +5119,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.16.0.tgz",
-			"integrity": "sha512-CAaRCkoJ83+XeObkY1aiswInVHCm5JBFVCCtkEVvRlbqNipHCMyhA3rg501Ww4AOYxsX9r2rvNbGaAPMGc6oug==",
+			"version": "5.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.19.1.tgz",
+			"integrity": "sha512-GDQvOtVVE3yk2sx+vYC3/k4QBXf1VckUT1KSNyfYt7swQk/Fxs7Tozb3EVF1zhzxEyMOiW8r9DUpKNVOn29tfQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5130,9 +5130,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.16.0.tgz",
-			"integrity": "sha512-ppjgUOjCFwLjH5XCDAfavRkIAj9DKEVGj12YMGL+dzSikbDU9L8VnMT1p08G1bAcBkTRLtBX8KkJJdyUI1JGsQ==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.19.1.tgz",
+			"integrity": "sha512-J5jhHvRbAPAOMkB3/tky4+MvW145HYS0DD0obgoafxnvPBL3zxCMvt6rRMtBnq+fMK02VkbuQ5KweZaQvv+bHg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5141,9 +5141,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.16.0.tgz",
-			"integrity": "sha512-AU6SFATdbUJsd/hqD6wUaZxbikibJ4L7RGpQ2MPUsXxXZCJU8pfPE3WWIOM1VemG4dJRJO+jk0lG8uH9pwdsfA==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.19.1.tgz",
+			"integrity": "sha512-tJUxE5j06UlYxRqmHQJoSYQmW8lvNaTY+rR/hoaGLxTZrp8ucTymqhDijnPAY2hYviGDFv6WqcYRABBJGV76Kg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5165,9 +5165,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.16.0.tgz",
-			"integrity": "sha512-xA1sbiQoqfk530JMAFGpThGbCjGeVaVitEdB3WYWnHY8JGmI6l5SeWaen2GlD4zbbCS+HE0Kn0sof1h5B9R26A==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.19.1.tgz",
+			"integrity": "sha512-g7Ww4rusTJBIBASOIRXyFOMDte0zyUJNv2xsE923tlGCniNVHA8tsnMh5O7eymW0JRyzgzcVB7bLi1HOz9WS3w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5187,17 +5187,17 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.2.0.tgz",
-			"integrity": "sha512-JKs2tEpkg6txe1emR+P7gw9OrSXvu89TMHuN1uk0wxdJeEqoF7HcxTdJBEaMHCz5HFhBHeuI5vShtX/WN6jf3g==",
+			"version": "22.5.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.5.1.tgz",
+			"integrity": "sha512-B8VqGpyl/JDyq8Oq659TzHrM29bEU9zRPNl2l767SgHMKS/kakhbDizOxpQF528VGxRIGtK5MLFz31zh1G+H5Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.16.0",
-				"@wordpress/prettier-config": "^4.16.0",
+				"@wordpress/babel-preset-default": "^8.19.1",
+				"@wordpress/prettier-config": "^4.19.1",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
@@ -5277,9 +5277,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.16.0.tgz",
-			"integrity": "sha512-W82L1PdIhJPNpEb2F+0NWzrDoUqZo6NnYID7qHCexBiagq4+QS4uydM6anyFvUNrpL51CmkCNu31Xi8HjpSTGg==",
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.19.1.tgz",
+			"integrity": "sha512-aZOf50V6+j1s+0pq/WZ37PZxu8Dn76ww2WJRYCXtk0sAO6EG2KoX2Gc9bKv0PKwOMss5aiza8pZgIYJFuxZMOw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7"
@@ -5290,13 +5290,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.16.0.tgz",
-			"integrity": "sha512-O4ZUvjS8AlYzTxvw7fmp3xk51rpKv1h2/dGFc/L+IB97UrCBAiC9HBv6FIHRF1gci4Vdu/QnCDw3qpC+N/2gCw==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.9.0.tgz",
+			"integrity": "sha512-pKFV9S/l0TFlm0mlWLW51hAoRDNmZPGnfEpNXq43VKZkm1cco3Z1E54PHMGk8HdCECHqYNiJuQJOBOlqcYmnVQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.16.0",
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^4.9.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -5311,9 +5311,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.16.0.tgz",
-			"integrity": "sha512-GFwoPBeOir9lV0ZCrkOapl7us+NqYphjeTRhZajNYr+grUCtvJYY0XzGZd8QuXKD9R5yBK42jgb4/9vc5tL2TA==",
+			"version": "8.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.19.1.tgz",
+			"integrity": "sha512-QSF/TmrUnK/DqkbRiYl9wVpdhQtoOPR3lVL5tk2RZYjjn4Cntrz5iaFA1njH/XeyJkdbhI3WqS2y46HeIqNQFg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5329,13 +5329,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.16.0.tgz",
-			"integrity": "sha512-2GXwvdFiSjpzCxXs8TrzPqAechoCmWvWqijs1ONRDNm8HB6Vq+2sFo3ndCQ9ISQCb4fRUb2LF+/hgVRgIpDmVg==",
+			"version": "12.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.19.1.tgz",
+			"integrity": "sha512-zCmFx+qak8Xyg8eYcXj6N6MN/MHhIMJ1bvSZHDCV2n9D08Hg0feMk2NBEfc6ddkJPbQpppNOPNIS1Qtx6drDfw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.16.0",
+				"@wordpress/jest-console": "^8.19.1",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -5348,9 +5348,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.16.0.tgz",
-			"integrity": "sha512-TCcaVQx76erSPWoGctLYUSCx2fOmT8vVBR2w8O/2q6+qEO4G4FiCYhj2tYliGNH/H9hQX/6QvfIRWIEoCnvMXQ==",
+			"version": "5.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.19.1.tgz",
+			"integrity": "sha512-YgOrnIE23oiZ4LNu2Jpyvty6HRY6E3jPBOv6X+Y/eq+DBX8pwGTmyOp7EFgT5ZuKqCL4iNA9/QC3h8u2PRIVQg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5362,13 +5362,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.16.0.tgz",
-			"integrity": "sha512-+rVpUQo+HXGFBvCLox45OxwT/U4hsDD8UpcDh8MAwFwrYf33GUGgdAhO5i4V3RyJiMmiZpsemkHFjlOg10kUjQ==",
+			"version": "5.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.19.1.tgz",
+			"integrity": "sha512-HAUj/S4Ljb5JtF9zUE66C7ZBk0MfJ0daGeNacrPkX/3H390UzujQDA0wrbdqkRNutJnUdvQKM4mm0RMPn6RjnA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^5.16.0",
+				"@wordpress/base-styles": "^5.19.1",
 				"autoprefixer": "^10.4.20"
 			},
 			"engines": {
@@ -5380,9 +5380,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.16.0.tgz",
-			"integrity": "sha512-raaEW2x+pPfIYXF7RUJGEH8zeYWd4esIE0bJbKTAJV0yM+RE/DOWsGLGPiVvLEAAPg2AkIZ7oX0UPOYsBrsBqw==",
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.19.1.tgz",
+			"integrity": "sha512-uoLDzk3QtXJSAm02y0MMHWNaS9UCSOg30xX+aiwOCiTcXP/W4si4kd6laFfLiyvN4VZxQin7AXwbX5rve7u2zA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5394,25 +5394,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "30.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.9.0.tgz",
-			"integrity": "sha512-tyfzDlI4Zplnw5BdMaO5QgItzEU6FsxK3bf2yZrx+fLjKwLndiTWk6ObDEW+tIrwWpCZv8d54z9mNMwIwgXVow==",
+			"version": "30.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.7.0.tgz",
+			"integrity": "sha512-vwrf6Xo1GXV2ug4xdYMgZ2CVpNNfArOEJyX6w9CafIRmLOm8GkVGSza0VlEoOh1BTqQPv/awq6uiOKVMbVNB5Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.16.0",
-				"@wordpress/browserslist-config": "^6.16.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.16.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.16.0",
-				"@wordpress/eslint-plugin": "^22.2.0",
-				"@wordpress/jest-preset-default": "^12.16.0",
-				"@wordpress/npm-package-json-lint-config": "^5.16.0",
-				"@wordpress/postcss-plugins-preset": "^5.16.0",
-				"@wordpress/prettier-config": "^4.16.0",
-				"@wordpress/stylelint-config": "^23.8.0",
+				"@wordpress/babel-preset-default": "*",
+				"@wordpress/browserslist-config": "*",
+				"@wordpress/dependency-extraction-webpack-plugin": "*",
+				"@wordpress/e2e-test-utils-playwright": "*",
+				"@wordpress/eslint-plugin": "*",
+				"@wordpress/jest-preset-default": "*",
+				"@wordpress/npm-package-json-lint-config": "*",
+				"@wordpress/postcss-plugins-preset": "*",
+				"@wordpress/prettier-config": "*",
+				"@wordpress/stylelint-config": "*",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -5448,8 +5448,8 @@
 				"react-refresh": "^0.14.0",
 				"read-pkg-up": "^7.0.1",
 				"resolve-bin": "^0.4.0",
-				"rtlcss": "^4.3.0",
-				"sass": "^1.54.0",
+				"rtlcss-webpack-plugin": "^4.0.7",
+				"sass": "^1.50.1",
 				"sass-loader": "^16.0.3",
 				"schema-utils": "^4.2.0",
 				"source-map-loader": "^3.0.0",
@@ -5469,7 +5469,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.49.1",
+				"@playwright/test": "^1.48.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -5506,9 +5506,9 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.8.0.tgz",
-			"integrity": "sha512-Fqf8GVZlaflq2n7JMxEk+KfVhgbDgdx/qs/R6ZxnR7RTC6c9RqGxSdUqdhtJyVkoNB3pWRG/aD1h7abKVEO3dA==",
+			"version": "23.11.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.11.1.tgz",
+			"integrity": "sha512-0CX6OeuOwjaAfofrlDHTkPjEHnWq5Mj8wdM5vx3ajXbnsvzNVdskNIKvKva+Z2c54sFwGXO20QRp0kUqFtflUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5525,9 +5525,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.16.0.tgz",
-			"integrity": "sha512-A9kkw/ye2qL9ZHvm1Eew8bvGVnNMq4fW0t5dakdDuVXyXtSOvZVT268JhP9QaD0FYzOFrmxL5Ks8Z6ufP1yLwg==",
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.19.1.tgz",
+			"integrity": "sha512-EXG2Q6HjpLOB7RXPHQRX0Ub4OZnndX/xJSoS5x7emlg94vNvIC7G3rxG1kZTgH5PhUpDQFx6rN1kXC/NQpCk7g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
@@ -5539,9 +5539,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.16.0.tgz",
-			"integrity": "sha512-XsgqRPvB+VSecXnD3VfvJJxhcdTTX4EkgdzvWspmQnw0rNCV636KByZVgolzYhvr3La9EgqO+MqXzwvPHg/xfQ==",
+			"version": "3.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.19.1.tgz",
+			"integrity": "sha512-h/dsieWGT6aCPCze2Qb3xShlGtg0CR4PJsHgBXvwuCRoCgQOgHGKHEJIeAzQQSidA6tggbYeEPwlmZk1g+WY8Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6103,6 +6103,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/async-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+			"integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6111,9 +6121,9 @@
 			"license": "MIT"
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.20",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+			"version": "10.4.21",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+			"integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -6131,11 +6141,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.23.3",
-				"caniuse-lite": "^1.0.30001646",
+				"browserslist": "^4.24.4",
+				"caniuse-lite": "^1.0.30001702",
 				"fraction.js": "^4.3.7",
 				"normalize-range": "^0.1.2",
-				"picocolors": "^1.0.1",
+				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"bin": {
@@ -6165,9 +6175,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.10.2",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
-			"integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+			"version": "4.10.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+			"integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -6175,9 +6185,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.7.9",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-			"integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+			"integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6354,6 +6364,33 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
+		"node_modules/babel-runtime": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+			"integrity": "sha512-zeCYxDePWYAT/DfmQWIHsMSFW2vv45UIwIAMjGvQVsTd47RwsiRH0uK1yzyWZ7LDBKdhnGDPM6NYEO5CZyhPrg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.10.0"
+			}
+		},
+		"node_modules/babel-runtime/node_modules/core-js": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+			"deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT"
+		},
+		"node_modules/babel-runtime/node_modules/regenerator-runtime": {
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+			"integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6385,14 +6422,14 @@
 			}
 		},
 		"node_modules/bare-os": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.4.0.tgz",
-			"integrity": "sha512-9Ous7UlnKbe3fMi7Y+qh0DwAup6A1JkYgPnjvMDNOlmnxNRQvQ/7Nst+OnUQKzk0iAT0m9BisbDVp9gCv8+ETA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.0.tgz",
+			"integrity": "sha512-BUrFS5TqSBdA0LwHop4OjPJwisqxGy6JsWVqV6qaFoe965qqtaKfDzHY5T2YA1gUL0ZeeQeA+4BBc1FJTcHiPw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"engines": {
-				"bare": ">=1.6.0"
+				"bare": ">=1.14.0"
 			}
 		},
 		"node_modules/bare-path": {
@@ -6407,9 +6444,9 @@
 			}
 		},
 		"node_modules/bare-stream": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.4.tgz",
-			"integrity": "sha512-G6i3A74FjNq4nVrrSTUz5h3vgXzBJnjmWAVlBWaZETkgu+LgKd7AiyOml3EDJY1AHlIbBHKDXE+TUT53Ff8OaA==",
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+			"integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -6586,9 +6623,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-			"integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+			"version": "4.24.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6605,9 +6642,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001669",
-				"electron-to-chromium": "^1.5.41",
-				"node-releases": "^2.0.18",
+				"caniuse-lite": "^1.0.30001688",
+				"electron-to-chromium": "^1.5.73",
+				"node-releases": "^2.0.19",
 				"update-browserslist-db": "^1.1.1"
 			},
 			"bin": {
@@ -6692,24 +6729,24 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.7.tgz",
-			"integrity": "sha512-AbfG7dAuYNjYxFUtL1lAqmlWdxczCJ47w7cFjhGcnGnUdwSo6VgmSojfoW3tUI12HUkgTJ5kqj78yyq6TsFtlg==",
+			"version": "1.8.9",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.9.tgz",
+			"integrity": "sha512-FicwAUyWnrtnd4QqYAoRlNs44/a1jTL7XDKqm5gJ90wz1DQPlC7U2Rd1Tydpv+E7WAr4sQHuw8Q8M3nZMAyecQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.6.0",
-				"keyv": "^5.2.3"
+				"hookified": "^1.7.1",
+				"keyv": "^5.3.1"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
-			"integrity": "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.1.tgz",
+			"integrity": "sha512-13hQT2q2VIwOoaJdJa7nY3J8UVbYtMTJFHnwm9LI+SaQRfUiM6Em9KZeOVTCKbMnGcRIL3NSUFpAdjZCq24nLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@keyv/serialize": "^1.0.2"
+				"@keyv/serialize": "^1.0.3"
 			}
 		},
 		"node_modules/call-bind": {
@@ -6732,9 +6769,9 @@
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-			"integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6746,14 +6783,14 @@
 			}
 		},
 		"node_modules/call-bound": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-			"integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"get-intrinsic": "^1.2.6"
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6838,9 +6875,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001685",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001685.tgz",
-			"integrity": "sha512-e/kJN1EMyHQzgcMEEgoo+YTCO1NGCmIYHk5Qk8jT6AazWemS5QFKJ5ShCJlH3GZrNIdZofcNCEwZqbMjjKzmnA==",
+			"version": "1.0.30001703",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001703.tgz",
+			"integrity": "sha512-kRlAGTRWgPsOj7oARC9m1okJEXdL/8fekFVcxA8Hl7GH4r/sN4OJn/i6Flde373T50KS7Y37oFbMwlE8+F42kQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7026,9 +7063,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-			"integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7416,9 +7453,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.40.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
-			"integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
+			"version": "3.41.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
+			"integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -7553,9 +7590,9 @@
 			}
 		},
 		"node_modules/csp_evaluator": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.1.tgz",
-			"integrity": "sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.5.tgz",
+			"integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -8236,9 +8273,9 @@
 			"license": "MIT"
 		},
 		"node_modules/devtools-protocol": {
-			"version": "0.0.1312386",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-			"integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+			"version": "0.0.1423531",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1423531.tgz",
+			"integrity": "sha512-z6cOcajZWxk80zvFnkTGa7tj3oqF+C5SnOF1KSMeAr5/WW/nLNHlEpKr7voSzMz8IaUoq5rjdI0Mqv5k/BUkhg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -8431,9 +8468,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.68",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.68.tgz",
-			"integrity": "sha512-FgMdJlma0OzUYlbrtZ4AeXjKxKPk6KT8WOP8BjcqxWtlg8qyJQjRzPJzUtUn5GBg1oQ26hFs7HOOHJMYiJRnvQ==",
+			"version": "1.5.115",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.115.tgz",
+			"integrity": "sha512-MN1nahVHAQMOz6dz6bNZ7apgqc9InZy7Ja4DBEVCTdeiUcegbyOYE9bi/f2Z/z6ZxLi0RxLpyJ3EGe+4h3w73A==",
 			"license": "ISC"
 		},
 		"node_modules/emittery": {
@@ -8701,9 +8738,9 @@
 			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8730,13 +8767,16 @@
 			}
 		},
 		"node_modules/es-shim-unscopables": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+			"integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.0"
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-to-primitive": {
@@ -9165,9 +9205,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9202,9 +9242,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9285,9 +9325,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.2.tgz",
-			"integrity": "sha512-1yI3/hf35wmlq66C8yOyrujQnel+v5l1Vop5Cl2I6ylyNTT1JbuUUnV3/41PzwTzcyDp/oF0jWE3HXvcH5AQOQ==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz",
+			"integrity": "sha512-qJ+y0FfCp/mQYQ/vWQ3s7eUlFEL4PyKfAJxsnYTJ4YT73nsJBWqmEpFryxV9OeUiqmsTsYJ5Y+KDNaeP31wrRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10582,9 +10622,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-			"integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -10610,13 +10650,19 @@
 			}
 		},
 		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-callable": "^1.1.3"
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/for-in": {
@@ -10818,18 +10864,18 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-			"integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
+				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.0",
+				"get-proto": "^1.0.1",
 				"gopd": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"hasown": "^2.0.2",
@@ -11283,9 +11329,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.6.0.tgz",
-			"integrity": "sha512-se7cpwTA+iA/eY548Bu03JJqBiEZAqU2jnyKdj5B5qurtBg64CZGHTgqCv4Yh7NWu6FGI09W61MCq+NoPj9GXA==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.7.1.tgz",
+			"integrity": "sha512-OXcdHsXeOiD7OJ5zvWj8Oy/6RCdLwntAX+wUrfemNcMGn6sux4xbEHi2QXwqePYhjQ/yvxxq2MvCRirdlHscBw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -11788,15 +11834,15 @@
 			}
 		},
 		"node_modules/intl-messageformat": {
-			"version": "10.7.11",
-			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.11.tgz",
-			"integrity": "sha512-IB2N1tmI24k2EFH3PWjU7ivJsnWyLwOWOva0jnXFa29WzB6fb0JZ5EMQGu+XN5lDtjHYFo0/UooP67zBwUg7rQ==",
+			"version": "10.7.15",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.15.tgz",
+			"integrity": "sha512-LRyExsEsefQSBjU2p47oAheoKz+EOJxSLDdjOaEjdriajfHsMXOmV/EhMvYSg9bAgCUHasuAC+mcUBe/95PfIg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@formatjs/ecma402-abstract": "2.3.2",
+				"@formatjs/ecma402-abstract": "2.3.3",
 				"@formatjs/fast-memoize": "2.2.6",
-				"@formatjs/icu-messageformat-parser": "2.9.8",
+				"@formatjs/icu-messageformat-parser": "2.11.1",
 				"tslib": "2"
 			}
 		},
@@ -11860,12 +11906,13 @@
 			"license": "MIT"
 		},
 		"node_modules/is-async-function": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-			"integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+			"integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"async-function": "^1.0.0",
 				"call-bound": "^1.0.3",
 				"get-proto": "^1.0.1",
 				"has-tostringtag": "^1.0.2",
@@ -11908,13 +11955,13 @@
 			}
 		},
 		"node_modules/is-boolean-object": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-			"integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+			"integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bound": "^1.0.2",
+				"call-bound": "^1.0.3",
 				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
@@ -12385,13 +12432,13 @@
 			}
 		},
 		"node_modules/is-weakref": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-			"integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+			"integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bound": "^1.0.2"
+				"call-bound": "^1.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13104,9 +13151,9 @@
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13522,19 +13569,19 @@
 			}
 		},
 		"node_modules/lighthouse": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.3.0.tgz",
-			"integrity": "sha512-OaLE8DasnwQkn2CBo2lKtD+IQv42mNP3T+Vaw29I++rAh0Zpgc6SM15usdIYyzhRMR5EWFxze5Fyb+HENJSh2A==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.4.0.tgz",
+			"integrity": "sha512-1p/YKQpMqfYVSKVOB43RG3xbnxkSUOG0zqVm/bxJHAaAHKrEACgFi8HZxD9CCTFrt+d/Q/x9gjDyeUDarm1SIg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@paulirish/trace_engine": "0.0.39",
+				"@paulirish/trace_engine": "0.0.44",
 				"@sentry/node": "^7.0.0",
 				"axe-core": "^4.10.2",
 				"chrome-launcher": "^1.1.2",
 				"configstore": "^5.0.1",
-				"csp_evaluator": "1.1.1",
-				"devtools-protocol": "0.0.1312386",
+				"csp_evaluator": "1.1.5",
+				"devtools-protocol": "0.0.1423531",
 				"enquirer": "^2.3.6",
 				"http-link-header": "^1.1.1",
 				"intl-messageformat": "^10.5.3",
@@ -13547,11 +13594,11 @@
 				"metaviewport-parser": "0.3.0",
 				"open": "^8.4.0",
 				"parse-cache-control": "1.0.1",
-				"puppeteer-core": "^23.10.4",
+				"puppeteer-core": "^24.3.0",
 				"robots-parser": "^3.0.1",
 				"semver": "^5.3.0",
 				"speedline-core": "^1.4.3",
-				"third-party-web": "^0.26.1",
+				"third-party-web": "^0.26.5",
 				"tldts-icann": "^6.1.16",
 				"ws": "^7.0.0",
 				"yargs": "^17.3.1",
@@ -13601,6 +13648,102 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
+			"integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"extract-zip": "^2.0.1",
+				"progress": "^2.0.3",
+				"proxy-agent": "^6.5.0",
+				"semver": "^7.7.1",
+				"tar-fs": "^3.0.8",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"browsers": "lib/cjs/main-cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/lighthouse/node_modules/@puppeteer/browsers/node_modules/semver": {
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/lighthouse/node_modules/puppeteer-core": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.4.0.tgz",
+			"integrity": "sha512-eFw66gCnWo0X8Hyf9KxxJtms7a61NJVMiSaWfItsFPzFBsjsWdmcNlBdsA1WVwln6neoHhsG+uTVesKmTREn/g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@puppeteer/browsers": "2.8.0",
+				"chromium-bidi": "2.1.2",
+				"debug": "^4.4.0",
+				"devtools-protocol": "0.0.1413902",
+				"typed-query-selector": "^2.12.0",
+				"ws": "^8.18.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-2.1.2.tgz",
+			"integrity": "sha512-vtRWBK2uImo5/W2oG6/cDkkHSm+2t6VHgnj+Rcwhb0pP74OoUb4GipyRX/T/y39gYQPhioP0DPShn+A7P6CHNw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"mitt": "^3.0.1",
+				"zod": "^3.24.1"
+			},
+			"peerDependencies": {
+				"devtools-protocol": "*"
+			}
+		},
+		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
+			"version": "0.0.1413902",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
+			"integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/lighthouse/node_modules/semver": {
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -13631,6 +13774,16 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/lighthouse/node_modules/zod": {
+			"version": "3.24.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -13845,9 +13998,9 @@
 			}
 		},
 		"node_modules/make-dir/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -14526,9 +14679,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
 			"license": "MIT"
 		},
 		"node_modules/normalize-package-data": {
@@ -14548,9 +14701,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -14637,9 +14790,9 @@
 			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -15049,9 +15202,9 @@
 			}
 		},
 		"node_modules/pac-proxy-agent": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
-			"integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15487,14 +15640,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+			"integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.49.1"
+				"playwright-core": "1.51.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -15507,9 +15660,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+			"integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -15553,9 +15706,9 @@
 			}
 		},
 		"node_modules/possible-typed-array-names": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15563,9 +15716,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.49",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-			"integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -15583,7 +15736,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.7",
+				"nanoid": "^3.3.8",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -16595,13 +16748,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/queue-tick": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-			"integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/quick-lru": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -17120,22 +17266,79 @@
 			}
 		},
 		"node_modules/rtlcss": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
-			"integrity": "sha512-FI+pHEn7Wc4NqKXMXFM+VAYKEj/mRIcW4h24YVwVtyjI+EqGrLc2Hx/Ny0lrZ21cBWU2goLy36eqMcNj3AQJig==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.5.0.tgz",
+			"integrity": "sha512-wzgMaMFHQTnyi9YOwsx9LjOxYXJPzS8sYnFaKm6R5ysvTkwzHiB0vxnbHwchHQT65PTdBjDG21/kQBWI7q9O7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"escalade": "^3.1.1",
+				"find-up": "^5.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.21",
+				"postcss": "^8.3.11",
 				"strip-json-comments": "^3.1.1"
 			},
 			"bin": {
 				"rtlcss": "bin/rtlcss.js"
+			}
+		},
+		"node_modules/rtlcss-webpack-plugin": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/rtlcss-webpack-plugin/-/rtlcss-webpack-plugin-4.0.7.tgz",
+			"integrity": "sha512-ouSbJtgcLBBQIsMgarxsDnfgRqm/AS4BKls/mz/Xb6HSl+PdEzefTR+Wz5uWQx4odoX0g261Z7yb3QBz0MTm0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-runtime": "~6.25.0",
+				"rtlcss": "^3.5.0"
+			}
+		},
+		"node_modules/rtlcss/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/rtlcss/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/rtlcss/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/run-con": {
@@ -17936,9 +18139,9 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+			"integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18206,14 +18409,13 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.21.1",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
-			"integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+			"integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-fifo": "^1.3.2",
-				"queue-tick": "^1.0.1",
 				"text-decoder": "^1.1.0"
 			},
 			"optionalDependencies": {
@@ -18523,9 +18725,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.13.2",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.2.tgz",
-			"integrity": "sha512-wDlgh0mRO9RtSa3TdidqHd0nOG8MmUyVKl+dxA6C1j8aZRzpNeEgdhFmU5y4sZx4Fc6r46p0fI7p1vR5O2DZqA==",
+			"version": "16.15.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.15.0.tgz",
+			"integrity": "sha512-OK6Rs7EPdcdmjqiDycadZY4fw3f5/TC1X6/tGjnF3OosbwCeNs7nG+79MCAtjEg7ckwqTJTsku08e0Rmaz5nUw==",
 			"dev": true,
 			"funding": [
 				{
@@ -18552,12 +18754,12 @@
 				"debug": "^4.3.7",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^10.0.5",
+				"file-entry-cache": "^10.0.6",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^7.0.1",
+				"ignore": "^7.0.3",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
 				"known-css-properties": "^0.35.0",
@@ -18566,14 +18768,14 @@
 				"micromatch": "^4.0.8",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.1.1",
-				"postcss": "^8.4.49",
+				"postcss": "^8.5.3",
 				"postcss-resolve-nested-selector": "^0.1.6",
 				"postcss-safe-parser": "^7.0.1",
-				"postcss-selector-parser": "^7.0.0",
+				"postcss-selector-parser": "^7.1.0",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
-				"supports-hyperlinks": "^3.1.0",
+				"supports-hyperlinks": "^3.2.0",
 				"svg-tags": "^1.0.0",
 				"table": "^6.9.0",
 				"write-file-atomic": "^5.0.1"
@@ -18633,19 +18835,19 @@
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.10.1.tgz",
-			"integrity": "sha512-CBqs0jecftIyhic6xba+4OvZUp4B0wNbX19w6Rq1fPo+lBDmTevk+olo8H7u/WQpTSDCDbBN4f3oocQurvXLTQ==",
+			"version": "6.11.1",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.11.1.tgz",
+			"integrity": "sha512-e4rYo0UY+BIMtGeGanghrvHTjcryxgZbyFxUedp8dLFqC4P70aawNdYjRrQxbnKhu3BNr4+lt5e/53tcKXiwFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "^3.0.1",
 				"is-plain-object": "^5.0.0",
 				"known-css-properties": "^0.35.0",
-				"mdn-data": "^2.14.0",
+				"mdn-data": "^2.15.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-selector-parser": "^7.0.0",
+				"postcss-selector-parser": "^7.1.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -18656,16 +18858,16 @@
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.14.0.tgz",
-			"integrity": "sha512-QjcSiIvUHjmXp5wNLClRjQeU0Zp+I2Dag+AhtQto0nyKYZ3IF/pUzCuHe7Bv77EC92XE5t3EXeEiEv/to2Bwig==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.18.0.tgz",
+			"integrity": "sha512-gtCy1yim/vpHF/tq3B4Z43x3zKWpYeb4IM3d/Mf4oMYcNuoXOYEaqtoFlLHw9zd7+WNN3jNh6/WXyUrD3OIiwQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-			"integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18765,25 +18967,25 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "10.0.5",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.5.tgz",
-			"integrity": "sha512-umpQsJrBNsdMDgreSryMEXvJh66XeLtZUwA8Gj7rHGearGufUFv6rB/bcXRFsiGWw/VeSUgUofF4Rf2UKEOrTA==",
+			"version": "10.0.7",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.7.tgz",
+			"integrity": "sha512-txsf5fu3anp2ff3+gOJJzRImtrtm/oa9tYLN0iTuINZ++EyVR/nRrg2fKYwvG/pXDofcrvvb0scEbX3NyW/COw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^6.1.5"
+				"flat-cache": "^6.1.7"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.5.tgz",
-			"integrity": "sha512-QR+2kN38f8nMfiIQ1LHYjuDEmZNZVjxuxY+HufbS3BW0EX01Q5OnH7iduOYRutmgiXb797HAKcXUeXrvRjjgSQ==",
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.7.tgz",
+			"integrity": "sha512-qwZ4xf1v1m7Rc9XiORly31YaChvKt6oNVHuqqZcoED/7O+ToyNVGobKsIAopY9ODcWpEDKEBAbrSOCBHtNQvew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cacheable": "^1.8.7",
-				"flatted": "^3.3.2",
-				"hookified": "^1.6.0"
+				"cacheable": "^1.8.9",
+				"flatted": "^3.3.3",
+				"hookified": "^1.7.1"
 			}
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
@@ -18861,9 +19063,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/postcss-selector-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-			"integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18927,9 +19129,9 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
-			"integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18940,7 +19142,7 @@
 				"node": ">=14.18"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -19156,9 +19358,9 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.11",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
-			"integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+			"version": "5.3.14",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
+			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19303,9 +19505,9 @@
 			"license": "MIT"
 		},
 		"node_modules/third-party-web": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.26.2.tgz",
-			"integrity": "sha512-taJ0Us0lKoYBqcbccMuDElSUPOxmBfwlHe1OkHQ3KFf+RwovvBHdXhbFk9XJVQE2vHzxbTwvwg5GFsT9hbDokQ==",
+			"version": "0.26.5",
+			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.26.5.tgz",
+			"integrity": "sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -19324,20 +19526,20 @@
 			"license": "MIT"
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.72",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.72.tgz",
-			"integrity": "sha512-FW3H9aCaGTJ8l8RVCR3EX8GxsxDbQXuwetwwgXA2chYdsX+NY1ytCBl61narjjehWmCw92tc1AxlcY3668CU8g==",
+			"version": "6.1.84",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.84.tgz",
+			"integrity": "sha512-NaQa1W76W2aCGjXybvnMYzGSM4x8fvG2AN/pla7qxcg0ZHbooOPhA8kctmOZUDfZyhDL27OGNbwAeig8P4p1vg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "6.1.72",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.72.tgz",
-			"integrity": "sha512-KBl9MBV9F5ue/o5AIrQGNLtdziva4rPQUQhg6hMwuZGxN3YO3/2COT6/rA+rfoPL/kBJRCFOnBAvH2dMfCvT8Q==",
+			"version": "6.1.84",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.84.tgz",
+			"integrity": "sha512-2e5XqGZRjlNEssjCfftUZSCvoY68KX+eLKRz7oyxUdT0E7YMKyjAZGWL34WqAKcM3y5lLBI3VDclAU+JYw9SlQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.72"
+				"tldts-core": "^6.1.84"
 			}
 		},
 		"node_modules/tmpl": {
@@ -20644,16 +20846,17 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-			"integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"for-each": "^0.3.3",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
 				"gopd": "^1.2.0",
 				"has-tostringtag": "^1.0.2"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.8.4",
+	"version": "1.8.5",
 	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
 	"main": "index.js",
 	"scripts": {
@@ -21,13 +21,13 @@
 	},
 	"homepage": "https://github.com/soderlind/super-admin-all-sites-menu#readme",
 	"devDependencies": {
-		"@wordpress/scripts": "^30.9.0",
-		"terser-webpack-plugin": "^5.3.11"
+		"@wordpress/scripts": "^30.7.0",
+		"terser-webpack-plugin": "^5.3.14"
 	},
 	"dependencies": {
 		"@soderlind/wp-project-version-sync": "^2.0.2",
-		"@wordpress/api-fetch": "^7.16.0",
-		"@wordpress/i18n": "^5.16.0",
+		"@wordpress/api-fetch": "^7.9.0",
+		"@wordpress/i18n": "^5.9.0",
 		"cross-spawn": "^7.0.6",
 		"dexie": "^4.0.11"
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Super Admin All Sites Menu ===
-Stable tag: 1.8.4
+Stable tag: 1.8.5
 Requires at least: 5.6  
 Tested up to: 6.7  
 Requires PHP: 8.0  

--- a/super-admin-all-sites-menu.php
+++ b/super-admin-all-sites-menu.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * Description: For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.
- * Version:     1.8.4
+ * Version:     1.8.5
  * Author:      Per Soderlind
  * Network:     true
  * Author URI:  https://soderlind.no


### PR DESCRIPTION
This pull request includes version updates and dependency changes across multiple files for the `super-admin-all-sites-menu` project. The most important changes include updating the version number and modifying the dependencies in `package.json`.

Version updates:

* [`build/index.js`](diffhunk://#diff-b45a82899e064eecd30590584dc256fbf4aecbf4a782d303c94091b56d659a50L3-R3): Updated the version from 1.8.4 to 1.8.5.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L4-R4): Updated the version from 1.8.4 to 1.8.5.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from 1.8.4 to 1.8.5.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L2-R2): Updated the stable tag from 1.8.4 to 1.8.5.
* [`super-admin-all-sites-menu.php`](diffhunk://#diff-f376cc60146d9f72a1b7bf6d03d2268dc3087c33dd26bc4a98cd1f87bdfe48afL15-R15): Updated the version from 1.8.4 to 1.8.5.

Dependency changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24-R30): Updated `@wordpress/scripts` from ^30.9.0 to ^30.7.0, `terser-webpack-plugin` from ^5.3.11 to ^5.3.14, `@wordpress/api-fetch` from ^7.16.0 to ^7.9.0, and `@wordpress/i18n` from ^5.16.0 to ^5.9.0.