### PR TITLE
Follow Administration Color Scheme for menu colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+### 1.12.0
+
+#### Added
+
+- Menu colors now follow the user's Administration Color Scheme instead of being hardcoded to the default "Fresh" palette
+- Hover/focus on menu items uses the scheme's highlight background (via `--wp-admin-theme-color`), matching the admin sidebar behavior
+
 ### 1.11.1
 
 #### Fixed

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => '9bf33b357ad71f73fef7');
+<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => 'a82fb6a8035da86fa674');

--- a/build/index.js
+++ b/build/index.js
@@ -1,6 +1,6 @@
 /*!
  * super-admin-all-sites-menu
- * version: 1.11.1
+ * version: 1.12.0
  * address: https://github.com/soderlind/super-admin-all-sites-menu#readme
  * author:  Per Søderlind
  * license: GPLv2

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "soderlind/super-admin-all-sites-menu",
 	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
-	"version": "1.11.1",
+	"version": "1.12.0",
 	"keywords": [
 		"wordpress",
 		"multisite",

--- a/css/all-sites-menu.css
+++ b/css/all-sites-menu.css
@@ -15,10 +15,9 @@
 	}
 	#wp-admin-bar-my-sites>.ab-sub-wrapper #wp-admin-bar-network-admin-default {
 		position: fixed;
-		background: #32373c;
+		background: inherit;
 	}
 	#wp-admin-bar-my-sites>.ab-sub-wrapper ul#wp-admin-bar-my-sites-list {
-		background-color: #464b50;
 		/* padding-bottom: 32px !important; */
 	}
 	#wp-admin-bar-my-sites>.ab-sub-wrapper ul#wp-admin-bar-my-sites-list li.menupop {
@@ -29,7 +28,15 @@
 		/* padding: 2em; */
 		/* left: 50%; */
 		/* transform: translate(-50%, -50%); */
-		background-color: #464b50;
+		background-color: inherit;
+	}
+	/* Match admin sidebar hover: highlight background + contrasting text. */
+	#wpadminbar .quicklinks .menupop ul.ab-sub-secondary > li > a:hover,
+	#wpadminbar .quicklinks .menupop ul.ab-sub-secondary > li > a:focus,
+	#wpadminbar .quicklinks .menupop ul.ab-sub-secondary .ab-submenu > li > a:hover,
+	#wpadminbar .quicklinks .menupop ul.ab-sub-secondary .ab-submenu > li > a:focus {
+		background-color: var(--wp-admin-theme-color, #2271b1);
+		color: #fff;
 	}
 	#wp-admin-bar-my-sites>.ab-sub-wrapper.site_single {
 		height: auto;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.11.1",
+	"version": "1.12.0",
 	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Super Admin All Sites Menu ===
-Stable tag: 1.11.1
+Stable tag: 1.12.0
 Requires at least: 5.6  
 Tested up to: 7.0  
 Requires PHP: 8.0  
@@ -120,6 +120,10 @@ You can use the following filters to override the defaults:
 2. Menu data are stored locally in IndexedDB.
 
 == Changelog ==
+
+= 1.12.0 =
+* Added: Menu colors now follow the user's Administration Color Scheme
+* Added: Hover/focus on menu items uses the scheme's highlight background, matching the admin sidebar
 
 = 1.11.1 =
 * Fixed search box styling inconsistency between admin and front-end pages

--- a/super-admin-all-sites-menu.php
+++ b/super-admin-all-sites-menu.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * Description: For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.
- * Version:     1.11.1
+ * Version:     1.12.0
  * Author:      Per Soderlind
  * Network:     true
  * Author URI:  https://soderlind.no
@@ -435,7 +435,7 @@ final class SuperAdminAllSitesMenu {
 			$jsdeps  = array_merge( $jsdeps, $file[ 'dependencies' ] );
 			$version = $file[ 'version' ];
 		}
-		wp_register_style( 'super-admin-all-sites-menu', plugin_dir_url( __FILE__ ) . 'css/all-sites-menu.css', [], $version );
+		wp_register_style( 'super-admin-all-sites-menu', plugin_dir_url( __FILE__ ) . 'css/all-sites-menu.css', [ 'admin-bar' ], $version );
 		wp_enqueue_style( 'super-admin-all-sites-menu' );
 
 		wp_register_script( 'super-admin-all-sites-menu', plugin_dir_url( __FILE__ ) . 'build/index.js', $jsdeps, $version, true );


### PR DESCRIPTION
- Remove hardcoded background colors (#32373c, #464b50) from CSS
- Use inherit for position:fixed elements so WP scheme colors cascade
- Add hover/focus highlight using --wp-admin-theme-color CSS variable
- Add admin-bar as stylesheet dependency for correct source order
- Bump version to 1.12.0