### PR TITLE
chore(deps): fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.11.0",
+	"version": "1.12.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "super-admin-all-sites-menu",
-			"version": "1.11.0",
+			"version": "1.12.1",
 			"license": "GPLv2",
 			"dependencies": {
-				"@wordpress/api-fetch": "^7.9.0",
+				"@wordpress/api-fetch": "^7.43.0",
 				"@wordpress/i18n": "^6.16.0",
-				"dexie": "^4.2.0"
+				"dexie": "^4.4.2"
 			},
 			"devDependencies": {
 				"@soderlind/wp-project-version-sync": "^2.0.2",
-				"@wordpress/scripts": "^31.6.0",
+				"@wordpress/scripts": "^31.8.0",
 				"cross-spawn": "^7.0.6",
 				"terser-webpack-plugin": "^5.3.14"
 			}
@@ -218,9 +218,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.7.tgz",
-			"integrity": "sha512-6Fqi8MtQ/PweQ9xvux65emkLQ83uB+qAVtfHkC9UodyHMIZdxNI01HjLCLUtybElp2KY2XNE0nOgyP1E1vXw9w==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+			"integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -409,23 +409,23 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/types": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1830,9 +1830,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-			"integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+			"integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2182,9 +2182,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-			"integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2272,9 +2272,9 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2284,9 +2284,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2394,9 +2394,9 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2567,9 +2567,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2640,9 +2640,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/schema": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2826,16 +2826,16 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
-			"version": "0.34.48",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
-			"version": "15.1.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-			"integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+			"version": "15.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+			"integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3330,14 +3330,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-core": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.11.tgz",
-			"integrity": "sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
+			"integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.11",
-				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -3352,15 +3352,15 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-fsa": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.11.tgz",
-			"integrity": "sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
+			"integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.11",
-				"@jsonjoy.com/fs-node-builtins": "4.56.11",
-				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-core": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -3375,17 +3375,17 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.11.tgz",
-			"integrity": "sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
+			"integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.11",
-				"@jsonjoy.com/fs-node-builtins": "4.56.11",
-				"@jsonjoy.com/fs-node-utils": "4.56.11",
-				"@jsonjoy.com/fs-print": "4.56.11",
-				"@jsonjoy.com/fs-snapshot": "4.56.11",
+				"@jsonjoy.com/fs-core": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"@jsonjoy.com/fs-print": "4.57.2",
+				"@jsonjoy.com/fs-snapshot": "4.57.2",
 				"glob-to-regex.js": "^1.0.0",
 				"thingies": "^2.5.0"
 			},
@@ -3401,9 +3401,9 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-builtins": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.11.tgz",
-			"integrity": "sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
+			"integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -3418,15 +3418,15 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-to-fsa": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.11.tgz",
-			"integrity": "sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
+			"integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-fsa": "4.56.11",
-				"@jsonjoy.com/fs-node-builtins": "4.56.11",
-				"@jsonjoy.com/fs-node-utils": "4.56.11"
+				"@jsonjoy.com/fs-fsa": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -3440,13 +3440,13 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-utils": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.11.tgz",
-			"integrity": "sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
+			"integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.11"
+				"@jsonjoy.com/fs-node-builtins": "4.57.2"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -3460,13 +3460,13 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-print": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.11.tgz",
-			"integrity": "sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
+			"integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
 				"tree-dump": "^1.1.0"
 			},
 			"engines": {
@@ -3481,14 +3481,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-snapshot": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.11.tgz",
-			"integrity": "sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
+			"integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@jsonjoy.com/buffers": "^17.65.0",
-				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
 				"@jsonjoy.com/json-pack": "^17.65.0",
 				"@jsonjoy.com/util": "^17.65.0"
 			},
@@ -5796,9 +5796,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.37",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-			"integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6778,13 +6778,13 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.43.0.tgz",
-			"integrity": "sha512-1Tetm4VIEKDIwrCsvDY0KjjrHvkEaSa2Qvld5gguY2ofcIszL3mR0tGezFaaaB14FHd7Zl0MpfpQY3KeQ+BatQ==",
+			"version": "7.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.44.0.tgz",
+			"integrity": "sha512-KZP5Y0AzUVPRbwCsp2MUNEjIyYPJdaa7ojzYyc/IVlaAlbXVdd0Ofk8UDf4l8PjtXkyyPs9pX9sFy5iNcrF2cQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.16.0",
-				"@wordpress/url": "^4.43.0"
+				"@wordpress/i18n": "^6.17.0",
+				"@wordpress/url": "^4.44.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -6792,9 +6792,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.43.0.tgz",
-			"integrity": "sha512-L2EOVoc0EXlz/QJRW1KuJxiKtVntD5bqFzMTizPmNdwr6BIyVOWs7mDOCldTTCKcYcLSGMbTFj7F24rKNC4Cmw==",
+			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.44.0.tgz",
+			"integrity": "sha512-6EQW8ysiQkct2MolHlhyqXfZ/Vgl0Cu9dCeHfPEf7S/8575qua1GnuDSFzEqU/8TIrEG88f2e2qP/R7VRB+EwQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6804,8 +6804,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.43.0",
-				"@wordpress/warning": "^3.43.0",
+				"@wordpress/browserslist-config": "^6.44.0",
+				"@wordpress/warning": "^3.44.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -7015,9 +7015,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.19.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.19.0.tgz",
-			"integrity": "sha512-SAZA6dhfC5X00s9PRrL9diY59WegiF0MuAWupkoKnYk3a2IAQbRUUTrh3j3wRyr08ljqefmifX5GR3hz/VwQaw==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.20.0.tgz",
+			"integrity": "sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7026,9 +7026,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.43.0.tgz",
-			"integrity": "sha512-W6Htq0S8g9RE02zwIB4HgbxwFeL9tijIleAIjp3pMuodP6ReRcWjvOX9O3DyfaRKrhl7JCFhT/M1RkKK3hQnYg==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.44.0.tgz",
+			"integrity": "sha512-lYtkO7U7ok9RfRBIHWvVWXhcOys6cQuLfwFr1bGuPTE6+LmVHmRyniMnImZlG8Jb3XE4pvH8gXT1ecXogpDI2Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7037,9 +7037,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.43.0.tgz",
-			"integrity": "sha512-4u7AvCEISGv9Q/sLHnV1+msZMKvHrDJ+R52Ezn3x2chIiOWFZWvr109BctwyUxvcn6SZgz9l0Ag88ffzdsjbqA==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.44.0.tgz",
+			"integrity": "sha512-bc6PfIUW//FxDu7DOuUoq2/oIQL2u8U33oDArFukTmyzf1fBWSIYKc2rpD3t3JMaWmnoiorlKgDpaFXfI6dCuA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7061,9 +7061,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.43.0.tgz",
-			"integrity": "sha512-suQCgtDVLRnGhdD7yWUVOTCGefW5perb0vTwQqWUbc/JyCdGnEztvGvpINXs7LV36U3YX7MYPEimCCcJc5frJA==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.44.0.tgz",
+			"integrity": "sha512-iUKHGH8TjW1s0cpkcHF6y/APOmy4YnwBfzdBNCITK4+4fuSZnTV7vZyzBU3adthGcBSMGQ9w8MTE2AzGLtlG3w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7083,15 +7083,15 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
-			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.44.0.tgz",
+			"integrity": "sha512-kVCRSwGMPFu7oBcAzN0VzwFQw3mwctUb/TEHkGeG5An1Uus6olruGJyvFwkHNtO9WRCdTXXunUaSk0CIA9+Wig==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.43.0",
+				"@wordpress/escape-html": "^3.44.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -7103,9 +7103,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
-			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
+			"version": "3.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.44.0.tgz",
+			"integrity": "sha512-nAEshSe6IYFr3G8sfY8o9pYNTRKvxocQ3DXs3KUesmdaEtrtJSlDmrMOI3FIgaYfv1PP6d+cDZpsygp6IZGo2w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7177,9 +7177,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
-			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
+			"version": "4.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.44.0.tgz",
+			"integrity": "sha512-6p2vFvoFaovqnKFnIoy6Kib2XJhTwaJ1VhMXp4tM2PhSLnFMXVm1TpcHeX/kH7E6sWKJACBrDR6FH2nGYMk5dA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7187,13 +7187,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
-			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.17.0.tgz",
+			"integrity": "sha512-v1SLBweg7CRzQ+5+WSC1U93i8h9d3AoB0YBvMsd6gWI5vO8Zh4YKlEMexvrHQC++WN83egwqux84fWEdeU0MUA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.43.0",
+				"@wordpress/hooks": "^4.44.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -7207,9 +7207,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.43.0.tgz",
-			"integrity": "sha512-cKkbZGXAwRc9GkQ6U0QQs3aa6N/dV/F6QZdMdcObb3cg+jXSw1N6k86Q5ZFSlpzYXrBgqNl3I59xq1cRifAA4Q==",
+			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.44.0.tgz",
+			"integrity": "sha512-2Dawx6Qh2zr0ZlFByFmvkfCukb6CzCrCFnTnHImdiwlQ7wKcmTaIR3QPomJg6fTxiwgBiWn9yeiO7N97vJ59eg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7225,13 +7225,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.43.0.tgz",
-			"integrity": "sha512-PY5HoTa5oQ+oIzxh6f4J9h0P1mqNDC0MoJuLGaw4/Yu+zBSvQuW67B9D29pQcSuLsLMtaR6R1Um/HmU+M//3rw==",
+			"version": "12.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.44.0.tgz",
+			"integrity": "sha512-v5gj1/IdPfPoOOor/UZxvbuYQ8NYE1CV+De27Kf9w3MzTh1Z2KwuyZGA163X9OYMdQY36D2GfT2aa7p0RpWaFA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.43.0",
+				"@wordpress/jest-console": "^8.44.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -7244,9 +7244,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.43.0.tgz",
-			"integrity": "sha512-W98SP/WpGaQ9VziO1Ez88J5Lhr7l63d44RWtANueHvAndCMm2E6PgVSQTMEKUzimWI+RqQlY8AcHBx1DPyacxA==",
+			"version": "5.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.44.0.tgz",
+			"integrity": "sha512-XVu8wrLegxsJULb5lHd3Z8enlgQUWA9d+3Lsa+7AiyL5jUqDaMR1RKvHVvqAsCnlc2h2qoJiWUU7YLCVQNXd9Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7258,13 +7258,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.43.0.tgz",
-			"integrity": "sha512-BlyQK1nb5TK0wLqnBiHpaz1ENngpZR8vf6gv3g2KCLstXJPl9WkM2g6GvKaDBOjodzVnGM2xs6tqlBlvfjKYxw==",
+			"version": "5.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.44.0.tgz",
+			"integrity": "sha512-D3GGSSmPKHUywK+pIHXsfnX6MXsjMb6rfQ33hX2hfOLZUR5VVt/DFJE3teinnyveQKOKeFcytiMr1pP2gH12RA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.19.0",
+				"@wordpress/base-styles": "^6.20.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -7277,9 +7277,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.43.0.tgz",
-			"integrity": "sha512-l52vxzgp61vfWq6fLIbAZl2efFMbEQ+BLGoekcyHw7h0rmg3u6YWTPdRRnzIfKAkSiArF8K80uvJ1eHYWiTMUg==",
+			"version": "4.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.44.0.tgz",
+			"integrity": "sha512-RT8Pc/dGOhMM9PwCsPamhkpIYx6zjTUDBIs/huVYKusByXImXQFoeZmaI3nK/UNus55woW6xyNNWdb2/nvvXgw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7291,9 +7291,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.43.0.tgz",
-			"integrity": "sha512-ADZB20UjyQgdL43uFkFE9tm49URMRphydi+ngaxbAJnT/3n5x7WSzfXMBqrdQOuBpdy44O9yHz7JtzLXRapkjQ==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.44.0.tgz",
+			"integrity": "sha512-fTR1HRshYIrN4yau/Z+zxY+oRFnJz/LS8XGeXx43PT5O4B25+4kO41ApdS9FG56erg8HqUB6HoqDUcReT5pzlQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7419,14 +7419,14 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.35.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.35.0.tgz",
-			"integrity": "sha512-rBgpD6St0tJZpX5OSipeZ8oAFRU3hQZAfF1BT+DTU+O821YWtwYYiUsIA/z7jCCfL4gUuNA9/ndIAffKMQZOtg==",
+			"version": "23.36.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.36.0.tgz",
+			"integrity": "sha512-UJIrrJjdHD28tzjHZLS/KmaJjuaVZ5r5zYHguPSJfa5lxXP6JEqYPN4sQV6Ebjd5YtB4ZPKNVQDJHLQqtgRSdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
-				"@wordpress/theme": "^0.10.0",
+				"@wordpress/theme": "^0.11.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -7437,6 +7437,33 @@
 			"peerDependencies": {
 				"stylelint": "^16.8.2",
 				"stylelint-scss": "^6.4.0"
+			}
+		},
+		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.11.0.tgz",
+			"integrity": "sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.44.0",
+				"@wordpress/private-apis": "^1.44.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/theme": {
@@ -7467,9 +7494,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.43.0.tgz",
-			"integrity": "sha512-FFq/KZUlhAszI9y232BpQ83+58CtRV5M0SFuv7pQq+DxNDuWNHp8gjdX9WOnHkO/MrKAyVTI0jX9YoWF2RNEZw==",
+			"version": "4.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.44.0.tgz",
+			"integrity": "sha512-kWalXttgtRwFy4szBPX9dJcqHErRC0V9JuZ7uxdrxxdXl6WNv+lx8SYpLx12q3Zk6zNIw73M8E5wHON7eyXZZw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"remove-accents": "^0.5.0"
@@ -7480,9 +7507,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.43.0.tgz",
-			"integrity": "sha512-hZn++Njsops73oG2DHpjgriUkHTgk1ykvZtHEDllPSNx5Zf6S8KJ00kcToHjIj/4p1iiDjag2zSX5Yi9ySJHvg==",
+			"version": "3.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.44.0.tgz",
+			"integrity": "sha512-avxdbIYhDuUh2qi2oiq7KeqYOVv2RubqV8UI/Q7bctZSFSXJE8RQGSR/W2YjABeyWBIjlyX/U5lOxVs2PIfy/w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7596,9 +7623,9 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"version": "0.5.17",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+			"integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7818,13 +7845,6 @@
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
-		},
-		"node_modules/argparse/node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
@@ -8107,9 +8127,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.27",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
 			"dev": true,
 			"funding": [
 				{
@@ -8127,8 +8147,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.1",
-				"caniuse-lite": "^1.0.30001774",
+				"browserslist": "^4.28.2",
+				"caniuse-lite": "^1.0.30001787",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -8160,9 +8180,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
-			"integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+			"integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -8170,15 +8190,25 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.6",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
 				"form-data": "^4.0.5",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/axobject-query": {
@@ -8265,14 +8295,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.16",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.16.tgz",
-			"integrity": "sha512-xaVwwSfebXf0ooE11BJovZYKhFjIvQo7TsyVpETuIeH2JHv0k/T6Y5j22pPTvqYqmpkxdlPAJlyJ0tfOJAoMxw==",
+			"version": "0.4.17",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+			"integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-define-polyfill-provider": "^0.6.7",
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -8280,13 +8310,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.1.tgz",
-			"integrity": "sha512-ENp89vM9Pw4kv/koBb5N2f9bDZsR0hpf3BdPMOg/pkS3pwO4dzNnQZVXtBbeyAadgm865DmQG2jMMLqmZXvuCw==",
+			"version": "0.14.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+			"integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.7",
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
 				"core-js-compat": "^3.48.0"
 			},
 			"peerDependencies": {
@@ -8294,13 +8324,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.7.tgz",
-			"integrity": "sha512-OTYbUlSwXhNgr4g6efMZgsO8//jA61P7ZbRX3iTT53VON8l+WQS8IAUEVo4a4cWknrg2W8Cj4gQhRYNCJ8GkAA==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+			"integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.7"
+				"@babel/helper-define-polyfill-provider": "^0.6.8"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -8373,9 +8403,9 @@
 			}
 		},
 		"node_modules/bare-fs": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
-			"integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+			"integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8398,9 +8428,9 @@
 			}
 		},
 		"node_modules/bare-os": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.1.tgz",
-			"integrity": "sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==",
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+			"integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -8418,20 +8448,24 @@
 			}
 		},
 		"node_modules/bare-stream": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.1.tgz",
-			"integrity": "sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+			"integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"streamx": "^2.21.0",
+				"streamx": "^2.25.0",
 				"teex": "^1.0.1"
 			},
 			"peerDependencies": {
+				"bare-abort-controller": "*",
 				"bare-buffer": "*",
 				"bare-events": "*"
 			},
 			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
 				"bare-buffer": {
 					"optional": true
 				},
@@ -8441,9 +8475,9 @@
 			}
 		},
 		"node_modules/bare-url": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-			"integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+			"integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8472,9 +8506,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.7",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
-			"integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
+			"version": "2.10.19",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+			"integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -8485,9 +8519,9 @@
 			}
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+			"integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8598,9 +8632,9 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8621,9 +8655,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"funding": [
 				{
@@ -8641,11 +8675,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -8780,15 +8814,15 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -8905,9 +8939,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001778",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
-			"integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
+			"version": "1.0.30001788",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+			"integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -9479,9 +9513,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-			"integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+			"integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9493,9 +9527,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-			"integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+			"integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -9603,9 +9637,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/css-declaration-sorter": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
-			"integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+			"integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -10418,9 +10452,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.313",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-			"integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+			"version": "1.5.339",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+			"integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -10484,9 +10518,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-			"integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+			"integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10568,9 +10602,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.24.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-			"integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+			"version": "1.24.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+			"integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10657,16 +10691,16 @@
 			}
 		},
 		"node_modules/es-iterator-helpers": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
-			"integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+			"integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
+				"call-bind": "^1.0.9",
 				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.24.1",
+				"es-abstract": "^1.24.2",
 				"es-errors": "^1.3.0",
 				"es-set-tostringtag": "^2.1.0",
 				"function-bind": "^1.1.2",
@@ -10678,8 +10712,7 @@
 				"has-symbols": "^1.1.0",
 				"internal-slot": "^1.1.0",
 				"iterator.prototype": "^1.1.5",
-				"math-intrinsics": "^1.1.0",
-				"safe-array-concat": "^1.1.3"
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -11054,9 +11087,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11325,9 +11358,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11442,9 +11475,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11544,9 +11577,9 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12306,9 +12339,9 @@
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"dev": true,
 			"funding": [
 				{
@@ -12633,9 +12666,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.7",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-			"integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12730,9 +12763,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13394,9 +13427,9 @@
 			}
 		},
 		"node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14691,16 +14724,16 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-			"version": "0.34.48",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
-			"version": "15.1.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-			"integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+			"version": "15.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+			"integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -15202,9 +15235,9 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "18.0.2",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-			"integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+			"version": "18.1.2",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+			"integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -15214,7 +15247,7 @@
 				"@hapi/pinpoint": "^2.0.1",
 				"@hapi/tlds": "^1.1.1",
 				"@hapi/topo": "^6.0.2",
-				"@standard-schema/spec": "^1.0.0"
+				"@standard-schema/spec": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 20"
@@ -15463,9 +15496,9 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.1.tgz",
-			"integrity": "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==",
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
+			"integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15599,16 +15632,16 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.40.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
-			"integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+			"version": "24.41.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.41.0.tgz",
+			"integrity": "sha512-rLIUri7E/NQ3APSEYCCozaSJx0u8Tu9wxO6BJwnvXmIgILSK3L0TombaVh3izp1njAGrO6H2ru0hcIrLF+gWLw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@puppeteer/browsers": "2.13.0",
 				"chromium-bidi": "14.0.0",
 				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1581282",
+				"devtools-protocol": "0.0.1595872",
 				"typed-query-selector": "^2.12.1",
 				"webdriver-bidi-protocol": "0.4.1",
 				"ws": "^8.19.0"
@@ -15632,9 +15665,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1581282",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
-			"integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+			"version": "0.0.1595872",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
+			"integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -16036,9 +16069,9 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16152,20 +16185,20 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "4.56.11",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.11.tgz",
-			"integrity": "sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==",
+			"version": "4.57.2",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+			"integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.11",
-				"@jsonjoy.com/fs-fsa": "4.56.11",
-				"@jsonjoy.com/fs-node": "4.56.11",
-				"@jsonjoy.com/fs-node-builtins": "4.56.11",
-				"@jsonjoy.com/fs-node-to-fsa": "4.56.11",
-				"@jsonjoy.com/fs-node-utils": "4.56.11",
-				"@jsonjoy.com/fs-print": "4.56.11",
-				"@jsonjoy.com/fs-snapshot": "4.56.11",
+				"@jsonjoy.com/fs-core": "4.57.2",
+				"@jsonjoy.com/fs-fsa": "4.57.2",
+				"@jsonjoy.com/fs-node": "4.57.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.2",
+				"@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+				"@jsonjoy.com/fs-node-utils": "4.57.2",
+				"@jsonjoy.com/fs-print": "4.57.2",
+				"@jsonjoy.com/fs-snapshot": "4.57.2",
 				"@jsonjoy.com/json-pack": "^1.11.0",
 				"@jsonjoy.com/util": "^1.9.0",
 				"glob-to-regex.js": "^1.0.1",
@@ -16367,9 +16400,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.1.tgz",
-			"integrity": "sha512-k7G3Y5QOegl380tXmZ68foBRRjE9Ljavx835ObdvmZjQ639izvZD8CS7BkWw1qKPPzHsGL/JDhl0uyU1zc2rJw==",
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+			"integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16584,9 +16617,9 @@
 			"license": "MIT"
 		},
 		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -16639,9 +16672,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.36",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+			"version": "2.0.37",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17543,9 +17576,9 @@
 			}
 		},
 		"node_modules/pkijs": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
-			"integrity": "sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+			"integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -17637,9 +17670,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -19052,9 +19085,9 @@
 			"license": "MIT"
 		},
 		"node_modules/regjsparser": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-			"integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+			"integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -19123,12 +19156,13 @@
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
-			"version": "1.22.11",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"is-core-module": "^2.16.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
@@ -19439,9 +19473,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.98.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
-			"integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+			"version": "1.99.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+			"integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19501,9 +19535,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-			"integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -19950,14 +19984,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -20310,6 +20344,13 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -20375,9 +20416,9 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -21241,9 +21282,9 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+			"integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -21308,9 +21349,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.46.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-			"integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+			"version": "5.46.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+			"integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -21435,9 +21476,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -21491,9 +21532,9 @@
 			"license": "MIT"
 		},
 		"node_modules/thingies": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
-			"integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+			"integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -21529,14 +21570,14 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -21590,20 +21631,20 @@
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.27",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
-			"integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+			"integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "7.0.27",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.27.tgz",
-			"integrity": "sha512-eSnMd1x/x/E/kRNyjP0wLmzxg0lcfBqPhKLAxtQ6Kd3pqZ0CM0Ty6K8HSFWXSSKokiGFzzdrypxgWOYiXDLwFA==",
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.28.tgz",
+			"integrity": "sha512-brkN3yIgYTzBpSxB71XYBwUMDgutmKmA+6TWzgGD/EPcvCc6LHMTRaYj9ik1u3BxhSW53qIK/7cgjA2rF7BgbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.27"
+				"tldts-core": "^7.0.28"
 			}
 		},
 		"node_modules/tldts/node_modules/tldts-core": {
@@ -21974,9 +22015,9 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -22405,9 +22446,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.105.4",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+			"version": "5.106.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+			"integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -22427,9 +22468,8 @@
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.3.1",
-				"mime-types": "^2.1.27",
+				"mime-db": "^1.54.0",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
@@ -22842,6 +22882,16 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/webpack/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/websocket-driver": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -23074,9 +23124,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
## Security Dependency Updates

This PR fixes security vulnerabilities detected by Dependabot.

### Changes
- Updated vulnerable dependencies to secure versions
- Applied `npm audit fix`, `pip-audit`, or equivalent for detected ecosystems

### Automated by
[gh-bump](https://github.com/soderlind/gh-bump) - Batch Dependabot fix automation

---


> ⚠️ **Review carefully** before merging. Some updates may introduce breaking changes.