### PR TITLE
v1.12.3: Remove last indirect switch_to_blog() path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+### 1.12.3
+
+#### Fixed
+
+- Removed last indirect `switch_to_blog()` path — siteurl fallback now derives URL from `$site->domain` + `$site->path` instead of accessing `$site->siteurl` (which triggers `WP_Site::get_details()`)
+
 ### 1.12.2
 
 #### Changed

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => 'da739b20a95bf519c7d8');
+<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => '6f3ce8ef89d54e70c2f5');

--- a/build/index.js
+++ b/build/index.js
@@ -1,6 +1,6 @@
 /*!
  * super-admin-all-sites-menu
- * version: 1.12.2
+ * version: 1.12.3
  * address: https://github.com/soderlind/super-admin-all-sites-menu#readme
  * author:  Per Søderlind
  * license: GPLv2

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "soderlind/super-admin-all-sites-menu",
 	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
-	"version": "1.12.2",
+	"version": "1.12.3",
 	"keywords": [
 		"wordpress",
 		"multisite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.12.2",
+	"version": "1.12.3",
 	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Super Admin All Sites Menu ===
-Stable tag: 1.12.2
+Stable tag: 1.12.3
 Requires at least: 5.6  
 Tested up to: 7.0  
 Requires PHP: 8.0  
@@ -120,6 +120,9 @@ You can use the following filters to override the defaults:
 2. Menu data are stored locally in IndexedDB.
 
 == Changelog ==
+
+= 1.12.3 =
+* Fixed: Removed last indirect `switch_to_blog()` path — siteurl fallback now derives URL from `$site->domain` + `$site->path` instead of accessing `$site->siteurl` (which triggers `WP_Site::get_details()`)
 
 = 1.12.2 =
 * Changed: Replaced row-level freshness checks with a revision-based snapshot protocol for IndexedDB cache hydration

--- a/super-admin-all-sites-menu.php
+++ b/super-admin-all-sites-menu.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * Description: For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.
- * Version:     1.12.2
+ * Version:     1.12.3
  * Author:      Per Soderlind
  * Network:     true
  * Author URI:  https://soderlind.no
@@ -361,7 +361,16 @@ final class SuperAdminAllSitesMenu {
 			$blogname = $site_options[ $blogid ][ 'blogname' ] ?? '';
 			$menu_id  = 'blog-' . $blogid;
 			$blavatar = '<div class="blavatar"></div>';
-			$siteurl  = $site_options[ $blogid ][ 'siteurl' ] ?? $site->siteurl;
+			$siteurl  = $site_options[ $blogid ][ 'siteurl' ] ?? '';
+
+			// Derive URL from wp_blogs row (domain + path) to stay fully switch-free.
+			// Accessing $site->siteurl triggers WP_Site::get_details() which calls switch_to_blog().
+			if ( ! $siteurl ) {
+				$scheme  = is_ssl() ? 'https' : 'http';
+				$path    = '/' === $site->path ? '' : untrailingslashit( $site->path );
+				$siteurl = set_url_scheme( 'http://' . $site->domain . $path, $scheme );
+			}
+
 			$adminurl = $siteurl . '/wp-admin';
 
 			if ( ! $blogname ) {


### PR DESCRIPTION
This pull request releases version 1.12.3 of the plugin and addresses a bug related to how site URLs are determined, removing the last indirect usage of `switch_to_blog()` for improved performance and reliability. The update ensures that the site URL is now derived directly from the site's domain and path, avoiding unnecessary function calls that could impact multisite setups. Several files have also been updated to reflect the new version.

### Bug Fix: Site URL Derivation

* The fallback for determining a site's URL in the `get_sites()` method was changed to derive the URL from `$site->domain` and `$site->path` instead of accessing `$site->siteurl`, which could trigger `WP_Site::get_details()` and indirectly call `switch_to_blog()`. This avoids unnecessary blog switching and improves efficiency in multisite environments.

### Version Bump

* Updated the plugin version from 1.12.2 to 1.12.3 in `super-admin-all-sites-menu.php`, `package.json`, `composer.json`, `build/index.js`, and `readme.txt`. [[1]](diffhunk://#diff-f376cc60146d9f72a1b7bf6d03d2268dc3087c33dd26bc4a98cd1f87bdfe48afL15-R15) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L4-R4) [[4]](diffhunk://#diff-b45a82899e064eecd30590584dc256fbf4aecbf4a782d303c94091b56d659a50L3-R3) [[5]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L2-R2)
* Updated the asset version in `build/index.asset.php` to reflect changes in the build.

### Documentation

* Updated the changelog in both `CHANGELOG.md` and `readme.txt` to document the fix and the new version. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R10) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R124-R126)