### PR TITLE
1.12.4: Fix compatibility with WordPress MU Domain Mapping plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+### 1.12.4
+
+#### Fixed
+
+- Fixed compatibility with WordPress MU Domain Mapping plugin — site URLs and name fallbacks now use the mapped domain instead of the original subdomain, restoring behaviour that regressed in 1.11.0
+
 ### 1.12.3
 
 #### Fixed

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => '6f3ce8ef89d54e70c2f5');
+<?php return array('dependencies' => array('wp-api-fetch', 'wp-i18n'), 'version' => '0d051a4b7f36e552979a');

--- a/build/index.js
+++ b/build/index.js
@@ -1,6 +1,6 @@
 /*!
  * super-admin-all-sites-menu
- * version: 1.12.3
+ * version: 1.12.4
  * address: https://github.com/soderlind/super-admin-all-sites-menu#readme
  * author:  Per Søderlind
  * license: GPLv2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.12.1",
+	"version": "1.12.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "super-admin-all-sites-menu",
-			"version": "1.12.1",
+			"version": "1.12.4",
 			"license": "GPLv2",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.43.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "super-admin-all-sites-menu",
-	"version": "1.12.3",
+	"version": "1.12.4",
 	"description": "For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Super Admin All Sites Menu ===
-Stable tag: 1.12.3
+Stable tag: 1.12.4
 Requires at least: 5.6  
 Tested up to: 7.0  
 Requires PHP: 8.0  
@@ -120,6 +120,9 @@ You can use the following filters to override the defaults:
 2. Menu data are stored locally in IndexedDB.
 
 == Changelog ==
+
+= 1.12.4 =
+* Fixed: Compatibility with WordPress MU Domain Mapping plugin — site URLs and name fallbacks now use the mapped domain instead of the original subdomain, restoring behaviour that regressed in 1.11.0
 
 = 1.12.3 =
 * Fixed: Removed last indirect `switch_to_blog()` path — siteurl fallback now derives URL from `$site->domain` + `$site->path` instead of accessing `$site->siteurl` (which triggers `WP_Site::get_details()`)

--- a/super-admin-all-sites-menu.php
+++ b/super-admin-all-sites-menu.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * GitHub Plugin URI: https://github.com/soderlind/super-admin-all-sites-menu
  * Description: For the super admin, replace WP Admin Bar My Sites menu with an All Sites menu.
- * Version:     1.12.3
+ * Version:     1.12.4
  * Author:      Per Soderlind
  * Network:     true
  * Author URI:  https://soderlind.no
@@ -556,7 +556,60 @@ final class SuperAdminAllSitesMenu {
 			$options[ (int) $row->blog_id ][ $row->option_name ] = $row->option_value;
 		}
 
+		// Override siteurl with the mapped domain when WordPress MU Domain Mapping is active.
+		$blog_ids    = array_map( fn( $site ) => (int) $site->blog_id, $sites );
+		$dm_mappings = $this->get_mu_domain_mappings( $blog_ids );
+		foreach ( $dm_mappings as $blog_id => $mapped_url ) {
+			$options[ $blog_id ][ 'siteurl' ] = $mapped_url;
+		}
+
 		return $options;
+	}
+
+	/**
+	 * Fetch active domain mappings from wp_domain_mapping for the given blog IDs.
+	 *
+	 * Supports the WordPress MU Domain Mapping plugin (0.5.x by Donncha O Caoimh).
+	 * That plugin stores mapped domains in a separate wp_domain_mapping table and
+	 * only overrides siteurl/home at runtime via pre_option filters. Because
+	 * batch_get_site_options reads the DB directly (bypassing those filters), the
+	 * original subdomain URL would otherwise be used instead of the mapped domain.
+	 *
+	 * Returns an empty array when the plugin is not active.
+	 *
+	 * @param int[] $blog_ids Blog IDs to look up.
+	 * @return array<int, string> Scheme + mapped domain URL keyed by blog_id.
+	 */
+	private function get_mu_domain_mappings( array $blog_ids ): array {
+		if ( [] === $blog_ids ) {
+			return [];
+		}
+
+		// The domain_mapping_siteurl() function is defined by the MU Domain Mapping
+		// plugin (0.5.x). Checking function_exists() is more reliable than SHOW TABLES
+		// because it confirms the plugin is actually loaded, not just that a table
+		// exists from a previous install.
+		if ( ! function_exists( 'domain_mapping_siteurl' ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		$dm_table = $wpdb->base_prefix . 'domain_mapping';
+		$ids      = implode( ',', array_map( 'intval', $blog_ids ) );
+		$scheme   = is_ssl() ? 'https' : 'http';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from base_prefix, IDs cast to int via intval.
+		$rows = $wpdb->get_results(
+			"SELECT blog_id, domain FROM {$dm_table} WHERE blog_id IN ({$ids}) AND active = 1"
+		);
+
+		$mappings = [];
+		foreach ( (array) $rows as $row ) {
+			$mappings[ (int) $row->blog_id ] = $scheme . '://' . $row->domain;
+		}
+
+		return $mappings;
 	}
 
 	/**


### PR DESCRIPTION
Site URLs and name fallbacks now use the mapped domain instead of the original subdomain, restoring behaviour that regressed in 1.11.0.

- Add get_mu_domain_mappings() to query wp_domain_mapping directly
- Wire into batch_get_site_options() to overwrite siteurl for mapped sites
- Guard with function_exists('domain_mapping_siteurl') to confirm plugin is loaded